### PR TITLE
Template Gallery: curated styles with favorites and one-click apply

### DIFF
--- a/thumbnailer/app/page.tsx
+++ b/thumbnailer/app/page.tsx
@@ -4,6 +4,7 @@ import styles from "./page.module.css";
 import { buildPrompt } from "../lib/prompt/builder";
 import { profiles } from "../lib/prompt/profiles";
 import TemplateGallery from "../components/TemplateGallery";
+import { curatedStyles, curatedMap } from "../lib/gallery/curatedStyles";
 
 type Frame = { dataUrl: string; b64: string };
 
@@ -52,7 +53,11 @@ export default function Home() {
   const [newStyleLabel, setNewStyleLabel] = useState<string>("");
   const [newStyleTemplate, setNewStyleTemplate] = useState<string>("");
 
+  const curatedProfiles: Record<string, { label: string; template: string }> = Object.fromEntries(
+    curatedStyles.map((s) => [s.id, { label: s.label, template: s.template }])
+  );
   const allProfiles: Record<string, { label: string; template: string }> = {
+    ...curatedProfiles,
     ...profiles,
     ...customStyleProfiles,
   };
@@ -188,7 +193,7 @@ export default function Home() {
     setLoading(true);
     setResults([]);
     try {
-      const templateOverride = customStyleProfiles[profile]?.template;
+      const templateOverride = customStyleProfiles[profile]?.template || curatedMap[profile]?.template;
       const finalPrompt = mode === "custom"
         ? (fullPrompt || "")
         : buildPrompt({

--- a/thumbnailer/app/page.tsx
+++ b/thumbnailer/app/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./page.module.css";
 import { buildPrompt } from "../lib/prompt/builder";
 import { profiles } from "../lib/prompt/profiles";
+import TemplateGallery from "../components/TemplateGallery";
 
 type Frame = { dataUrl: string; b64: string };
 
@@ -322,6 +323,14 @@ export default function Home() {
                 </select>
               </label>
             </div>
+
+            {/* Template Gallery */}
+            <TemplateGallery
+              currentId={profile}
+              onApply={(id) => setProfile(id)}
+              readOnly={mode === "custom"}
+            />
+
 
             <label style={{ display: "grid", gap: 6 }}>
               <span>Headline</span>

--- a/thumbnailer/components/TemplateGallery.tsx
+++ b/thumbnailer/components/TemplateGallery.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { curatedStyles, isBuiltinProfileId } from "../lib/gallery/curatedStyles";
+
+export default function TemplateGallery(props: {
+  currentId: string;
+  onApply: (id: string) => void;
+  readOnly?: boolean;
+}) {
+  const { currentId, onApply, readOnly } = props;
+
+  const [favorites, setFavorites] = useState<Record<string, boolean>>({});
+  const [showOnlyFavs, setShowOnlyFavs] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem("cg_style_favs_v1");
+      if (raw) setFavorites(JSON.parse(raw));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try { localStorage.setItem("cg_style_favs_v1", JSON.stringify(favorites)); } catch {}
+  }, [favorites]);
+
+  const list = useMemo(() => {
+    return curatedStyles.filter((s) => (showOnlyFavs ? favorites[s.id] : true));
+  }, [favorites, showOnlyFavs]);
+
+  const toggleFav = (id: string) => {
+    setFavorites((f) => ({ ...f, [id]: !f[id] }));
+  };
+
+  return (
+    <section style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <h3 style={{ margin: 0 }}>Template Gallery</h3>
+        <label style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={showOnlyFavs} onChange={(e) => setShowOnlyFavs(e.target.checked)} />
+          <span>Favorites only</span>
+        </label>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {list.map((s) => (
+          <article key={s.id} style={{ border: "1px solid #ddd", borderRadius: 8, overflow: "hidden" }}>
+            <div style={{ position: "relative" }}>
+              <img src={s.previewUrl} alt={s.label} style={{ display: "block", width: "100%" }} />
+              <button
+                onClick={() => toggleFav(s.id)}
+                title={favorites[s.id] ? "Unfavorite" : "Favorite"}
+                style={{
+                  position: "absolute",
+                  top: 8,
+                  right: 8,
+                  background: favorites[s.id] ? "#ef4444" : "#00000088",
+                  color: "white",
+                  border: "none",
+                  borderRadius: 999,
+                  padding: "6px 10px",
+                  cursor: "pointer",
+                }}
+              >
+                {favorites[s.id] ? "\u2665" : "\u2661"}
+              </button>
+            </div>
+            <div style={{ padding: 10, display: "grid", gap: 6 }}>
+              <div style={{ fontWeight: 600, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <span>{s.label}</span>
+                {isBuiltinProfileId(s.id) && (
+                  <span style={{ fontSize: 12, opacity: 0.7 }}>Built-in</span>
+                )}
+              </div>
+              <p style={{ margin: 0, fontSize: 12, opacity: 0.8, lineHeight: 1.3 }}>{s.template}</p>
+              <div style={{ display: "flex", gap: 8, marginTop: 6 }}>
+                <button
+                  onClick={() => onApply(s.id)}
+                  disabled={readOnly || currentId === s.id}
+                  style={{ cursor: readOnly || currentId === s.id ? "default" : "pointer" }}
+                  title={readOnly ? "Switch to Presets mode to apply" : undefined}
+                >
+                  {currentId === s.id ? "Active" : readOnly ? "Apply (Presets only)" : "Apply"}
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/thumbnailer/lib/gallery/curatedStyles.ts
+++ b/thumbnailer/lib/gallery/curatedStyles.ts
@@ -1,0 +1,83 @@
+import { profiles } from "../prompt/profiles";
+
+export type StyleCard = {
+  id: string;
+  label: string;
+  template: string;
+  previewUrl: string;
+  builtin?: boolean;
+};
+
+const palette = [
+  "#4F46E5",
+  "#059669",
+  "#DC2626",
+  "#7C3AED",
+  "#2563EB",
+  "#EA580C",
+  "#16A34A",
+  "#DB2777",
+  "#0EA5E9",
+  "#64748B",
+  "#F59E0B",
+  "#14B8A6",
+];
+
+function svgDataUrl(label: string, bg: string, fg = "#ffffff"): string {
+  const text = label.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const svg = `<?xml version="1.0" encoding="UTF-8"?><svg xmlns='http://www.w3.org/2000/svg' width='480' height='270' viewBox='0 0 480 270'>
+  <defs>
+    <linearGradient id='g' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='${bg}' stop-opacity='0.95'/>
+      <stop offset='100%' stop-color='${bg}' stop-opacity='0.8'/>
+    </linearGradient>
+  </defs>
+  <rect width='100%' height='100%' fill='url(#g)'/>
+  <rect x='16' y='16' width='448' height='238' rx='12' ry='12' fill='rgba(0,0,0,0.18)'/>
+  <text x='50%' y='54%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, ui-sans-serif, system-ui' font-size='28' font-weight='700' fill='${fg}'>${text}</text>
+</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+const builtinCards: StyleCard[] = Object.entries(profiles).map(([id, p], i) => ({
+  id,
+  label: p.label,
+  template: p.template,
+  previewUrl: svgDataUrl(p.label, palette[i % palette.length]),
+  builtin: true,
+}));
+
+const extras: StyleCard[] = [
+  {
+    id: "cinematic",
+    label: "Cinematic",
+    template:
+      "Moody teal-orange grade, shallow depth of field subject, widescreen bars motif, bold minimalist title, dramatic lighting and atmosphere.",
+    previewUrl: svgDataUrl("Cinematic", palette[9]),
+  },
+  {
+    id: "retro-vaporwave",
+    label: "Retro Vaporwave",
+    template:
+      "80s retro vaporwave aesthetic: neon grid, sunset gradient, chrome text, palm silhouettes, nostalgic synthwave vibe with high contrast.",
+    previewUrl: svgDataUrl("Retro Vaporwave", palette[10]),
+  },
+  {
+    id: "minimal-mono",
+    label: "Minimal Mono",
+    template:
+      "Ultra minimal black-and-white style, large sans-serif headline, single accent shape, high whitespace and strong hierarchy for clarity.",
+    previewUrl: svgDataUrl("Minimal Mono", palette[11]),
+  },
+];
+
+export const curatedStyles: StyleCard[] = [...builtinCards, ...extras];
+
+export const curatedMap: Record<string, StyleCard> = Object.fromEntries(
+  curatedStyles.map((s) => [s.id, s])
+);
+
+export function isBuiltinProfileId(id: string): boolean {
+  return Object.prototype.hasOwnProperty.call(profiles as Record<string, unknown>, id);
+}
+


### PR DESCRIPTION
Implements Template Gallery for curated “house styles”.

- Adds curated styles data with example preview images (SVG data URLs)
- New TemplateGallery component: responsive grid, favorite/unfavorite with localStorage, quick Apply
- Integrates gallery into Presets mode UI; Apply switches the active profile
- Curated styles are available in the Profile dropdown and feed into prompt builder
- Favorites persisted in `cg_style_favs_v1`

Acceptance criteria coverage:
- At least 10 styles (built-ins + 3 curated extras), preview cards shown
- Selecting (Apply) sets active template and immediately affects prompt building
- Favorites filter and persistence implemented
- Works with both Presets and Custom modes (Apply disabled in Custom mode)

Closes #3.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author