### PR TITLE
Auth modal + UI tweaks: smaller video preview, remove Pricing from nav, clearer free-after-signup messaging

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
             <Link href="/" className="nb-brand">Creator Tool Hub</Link>
             <nav className="nb-nav">
               <Link href="/thumbnails" className="nb-navlink">Thumbnail Creator</Link>
-              <Link href="/pricing" className="nb-navlink">Pricing</Link>
+
             </nav>
             <AuthButton />
           </header>


### PR DESCRIPTION
Summary
- Shrink video scrub preview to ~75% and center it
- Remove Pricing from global navbar (kept access in Dashboard)
- Improve unauthenticated UX on /thumbnails:
  * Show clearer message ("free after sign-up")
  * Intercept Generate when logged out to open a modal with Sign in button
  * Keep server 401 fallback to trigger modal as well
- Generate button shows "(Free after sign-up)" when logged out

Files touched
- app/layout.tsx
- app/thumbnails/page.tsx

Notes
- No dependency changes
- Styling kept minimal and inline to match existing neobrutalist UI

Please review copy, placement, and whether we also want a dedicated Pricing/credits link in Dashboard beyond the existing Upgrade button.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author