### PR TITLE
Hotfix: make /api/generate streaming opt-in with JSON fallback; reorder auth/credit checks; minor progress UI tweak

### DIFF
--- a/app/thumbnails/page.tsx
+++ b/app/thumbnails/page.tsx
@@ -891,25 +891,25 @@ export default function Home() {
                 type="text"
                 placeholder="3–5 word hook (optional)"
                 value={headline}
-
-          {loading && (
-            <div style={{ marginTop: 12 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, fontSize: 12 }}>
-                <strong>Progress</strong>
-                <span>
-                  {progressTotal > 0 ? `${progressDone}/${progressTotal}` : (results.length > 0 ? `${results.length}…` : 'starting…')}
-                </span>
-              </div>
-              <div style={{ height: 8, background: '#eee', border: '1px solid #ccc', borderRadius: 6, overflow: 'hidden' }}>
-                <div style={{ height: '100%', width: `${Math.min(100, Math.round((progressDone / (progressTotal || Math.max(1, results.length))) * 100))}%`, background: 'linear-gradient(90deg, #ff3b3b, #ff7f50)', transition: 'width .2s ease' }} />
-              </div>
-            </div>
-          )}
-
                 onChange={(e) => setHeadline(e.target.value)}
                 className={styles.input}
               />
             </label>
+
+            {loading && (
+              <div style={{ marginTop: 12 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, fontSize: 12 }}>
+                  <strong>Progress</strong>
+                  <span>
+                    {progressTotal > 0 ? `${progressDone}/${progressTotal}` : (results.length > 0 ? `${results.length}…` : 'starting…')}
+                  </span>
+                </div>
+                <div style={{ height: 8, background: '#eee', border: '1px solid #ccc', borderRadius: 6, overflow: 'hidden' }}>
+                  <div style={{ height: '100%', width: `${Math.min(100, Math.round((progressDone / (progressTotal || Math.max(1, results.length))) * 100))}%`, background: 'linear-gradient(90deg, #ff3b3b, #ff7f50)', transition: 'width .2s ease' }} />
+                </div>
+              </div>
+            )}
+
 
             {/* Colors, layout, subject, and in-parent preset management removed in favor of card-centric editing */}
 


### PR DESCRIPTION
This hotfix stabilizes /api/generate in production by making streaming opt-in (compatible with existing clients/proxies) and ensuring sensible error ordering.

What changed
- Cloudflare Worker (workers/generate/src/index.ts)
  - GET /api/generate returns 200 { status: "ok" } (health)
  - POST /api/generate now has two modes:
    - NDJSON streaming only when Accept: application/x-ndjson is sent or ?stream=1 is present
    - Otherwise, returns a single JSON payload after completion (backwards-compatible)
  - Reordered checks so unauthenticated requests return 401 before model/config errors
  - Autumn credit check made resilient: if AUTUMN_SECRET_KEY is unset or check fails, it won’t crash the request (continues best‑effort unless explicitly disallowed)
- Client (app/thumbnails/page.tsx)
  - Minor UI placement tweak: progress bar renders cleanly under the headline field

Why
- Some clients/networks didn’t tolerate always-streaming responses, causing breakage. Opt-in streaming avoids QUIC idle issues while maintaining compatibility.
- Better error ordering avoids confusing 500s when the user is not signed in.

Local verification
- wrangler dev: GET /api/generate -> 200 health
- POST /api/generate unauthenticated -> 401 Unauthorized (expected)
- Streaming enabled when Accept header is provided; otherwise JSON fallback works.

Deployment
- After merge, deploy the Worker:
  - cd workers/generate
  - wrangler deploy

Follow-ups (optional)
- Consider adding a client-side cancel button to abort streaming
- Add automated tests for NDJSON parsing path

---
PR opened by Augment Agent (limited to this repository).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author