### PR TITLE
Add generation history page with pagination and filtering (fixes #19)

### DIFF
--- a/app/generations/page.module.css
+++ b/app/generations/page.module.css
@@ -1,0 +1,378 @@
+.container {
+  min-height: 100vh;
+  padding: 0;
+}
+
+.main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  color: #111;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: #666;
+  margin: 0;
+}
+
+.refreshButton {
+  padding: 0.75rem 1.5rem;
+  background: var(--nb-accent, #0070f3);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: opacity 0.2s;
+}
+
+.refreshButton:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.refreshButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.filters {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  padding: 1rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filterGroup label {
+  font-weight: 600;
+  color: #333;
+}
+
+.select {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.searchInput {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 1rem;
+  min-width: 250px;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #666;
+}
+
+.emptyState p {
+  font-size: 1.2rem;
+  margin: 0.5rem 0;
+}
+
+.emptyHint {
+  font-size: 1rem !important;
+  opacity: 0.7;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  background: white;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.imageContainer {
+  position: relative;
+  width: 100%;
+  height: 180px;
+  overflow: hidden;
+  background: #f0f0f0;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.statusBadge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 12px;
+  border-radius: 4px;
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.noPreview {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f0f0;
+  color: #999;
+  font-size: 14px;
+}
+
+.cardContent {
+  padding: 1rem;
+}
+
+.date {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+.meta {
+  font-size: 12px;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.prompt {
+  font-size: 12px;
+  color: #666;
+  line-height: 1.4;
+  margin-top: 0.5rem;
+}
+
+.loadMoreContainer {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.loadMoreButton {
+  padding: 0.75rem 2rem;
+  background: white;
+  color: var(--nb-accent, #0070f3);
+  border: 2px solid var(--nb-accent, #0070f3);
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.loadMoreButton:hover:not(:disabled) {
+  background: var(--nb-accent, #0070f3);
+  color: white;
+}
+
+.loadMoreButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Modal Styles */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal {
+  background: white;
+  border-radius: 12px;
+  max-width: 900px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.modalHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  color: #666;
+  line-height: 1;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  color: #333;
+}
+
+.modalContent {
+  padding: 1.5rem;
+}
+
+.detailRow {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: start;
+}
+
+.detailRow strong {
+  color: #333;
+}
+
+.fullPrompt {
+  margin: 0;
+  line-height: 1.6;
+  color: #666;
+}
+
+.outputsSection {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #ddd;
+}
+
+.outputsSection > strong {
+  display: block;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.outputsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.outputCard {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  background: white;
+}
+
+.outputImage {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  display: block;
+}
+
+.downloadButton {
+  width: 100%;
+  padding: 0.75rem;
+  background: var(--nb-accent, #0070f3);
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: opacity 0.2s;
+}
+
+.downloadButton:hover {
+  opacity: 0.9;
+}
+
+@media (max-width: 768px) {
+  .title {
+    font-size: 2rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .filterGroup {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .searchInput {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .detailRow {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .outputsGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/generations/page.tsx
+++ b/app/generations/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useHybridStorage } from "@/lib/storage/useHybridStorage";
+import { CloudGeneration } from "@/lib/storage/client";
+import AuthGuard from "@/components/AuthGuard";
+import styles from "./page.module.css";
+
+export default function GenerationsPage() {
+  const hybridStorage = useHybridStorage();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [selectedGeneration, setSelectedGeneration] = useState<CloudGeneration | null>(null);
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Initial load
+  useEffect(() => {
+    if (hybridStorage.isCloudEnabled && hybridStorage.generations.length === 0) {
+      hybridStorage.refreshGenerations({ limit: 20 });
+    }
+  }, [hybridStorage.isCloudEnabled]);
+
+  // Filter generations based on status and search
+  const filteredGenerations = hybridStorage.generations.filter(gen => {
+    const matchesStatus = statusFilter === "all" || gen.status === statusFilter;
+    const matchesSearch = searchQuery === "" ||
+      gen.prompt.toLowerCase().includes(searchQuery.toLowerCase());
+    return matchesStatus && matchesSearch;
+  });
+
+  const handleRefresh = async () => {
+    await hybridStorage.refreshGenerations({ limit: 20 });
+  };
+
+  const handleLoadMore = async () => {
+    if (!hybridStorage.isCloudEnabled || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      const lastGen = hybridStorage.generations[hybridStorage.generations.length - 1];
+      if (lastGen) {
+        await hybridStorage.refreshGenerations({
+          limit: 20,
+          before: lastGen.created_at
+        });
+        // If we got fewer than requested, there are no more
+        setHasMore(hybridStorage.generations.length % 20 === 0);
+      }
+    } catch (error) {
+      console.error("Failed to load more generations:", error);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
+  const handleSelectGeneration = (gen: CloudGeneration) => {
+    setSelectedGeneration(gen);
+  };
+
+  const handleCloseDetail = () => {
+    setSelectedGeneration(null);
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "complete": return "#28a745";
+      case "failed": return "#dc3545";
+      case "running": return "#ffc107";
+      case "pending": return "#6c757d";
+      default: return "#6c757d";
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <main className={styles.main}>
+        <AuthGuard>
+          <div className={styles.header}>
+            <div>
+              <h1 className={styles.title}>Generation History</h1>
+              <p className={styles.subtitle}>
+                Browse and access all your past thumbnail generations
+              </p>
+            </div>
+            <button
+              onClick={handleRefresh}
+              disabled={hybridStorage.isLoading}
+              className={styles.refreshButton}
+            >
+              {hybridStorage.isLoading ? "Loading..." : "Refresh"}
+            </button>
+          </div>
+
+          {/* Filters */}
+          <div className={styles.filters}>
+            <div className={styles.filterGroup}>
+              <label htmlFor="status-filter">Status:</label>
+              <select 
+                id="status-filter"
+                value={statusFilter} 
+                onChange={(e) => setStatusFilter(e.target.value)}
+                className={styles.select}
+              >
+                <option value="all">All</option>
+                <option value="complete">Complete</option>
+                <option value="failed">Failed</option>
+                <option value="running">Running</option>
+                <option value="pending">Pending</option>
+              </select>
+            </div>
+            <div className={styles.filterGroup}>
+              <label htmlFor="search-input">Search:</label>
+              <input
+                id="search-input"
+                type="text"
+                placeholder="Search by prompt..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className={styles.searchInput}
+              />
+            </div>
+          </div>
+
+          {/* Generations Grid */}
+          {!hybridStorage.isCloudEnabled ? (
+            <div className={styles.emptyState}>
+              <p>Please sign in to view your generation history.</p>
+            </div>
+          ) : filteredGenerations.length === 0 ? (
+            <div className={styles.emptyState}>
+              <p>No generations found.</p>
+              {hybridStorage.generations.length > 0 && (
+                <p className={styles.emptyHint}>
+                  Try adjusting your filters or search query.
+                </p>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className={styles.grid}>
+                {filteredGenerations.map((gen) => {
+                  const preview = gen.preview_url || gen.outputs?.[0]?.url;
+                  return (
+                    <div
+                      key={gen.id}
+                      className={styles.card}
+                      onClick={() => handleSelectGeneration(gen)}
+                    >
+                      {/* Preview Image */}
+                      {preview ? (
+                        <div className={styles.imageContainer}>
+                          <img
+                            src={preview}
+                            alt={gen.prompt ? gen.prompt.slice(0, 60) : `Generation ${gen.id}`}
+                            className={styles.image}
+                          />
+                          <div 
+                            className={styles.statusBadge}
+                            style={{ backgroundColor: getStatusColor(gen.status) }}
+                          >
+                            {gen.status}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className={styles.noPreview}>
+                          <span>No preview</span>
+                        </div>
+                      )}
+
+                      {/* Generation Info */}
+                      <div className={styles.cardContent}>
+                        <div className={styles.date}>
+                          {new Date(gen.created_at).toLocaleDateString()} at{" "}
+                          {new Date(gen.created_at).toLocaleTimeString()}
+                        </div>
+                        <div className={styles.meta}>
+                          Variants: {gen.outputs?.length ?? gen.variants_requested ?? 0}
+                        </div>
+                        {gen.prompt && (
+                          <div className={styles.prompt}>
+                            {gen.prompt.length > 80
+                              ? `${gen.prompt.substring(0, 80)}...`
+                              : gen.prompt}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Load More Button */}
+              {hasMore && statusFilter === "all" && searchQuery === "" && (
+                <div className={styles.loadMoreContainer}>
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={isLoadingMore || hybridStorage.isLoading}
+                    className={styles.loadMoreButton}
+                  >
+                    {isLoadingMore || hybridStorage.isLoading ? "Loading..." : "Load More"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </AuthGuard>
+      </main>
+
+      {/* Generation Detail Modal */}
+      {selectedGeneration && (
+        <GenerationDetailModal
+          generation={selectedGeneration}
+          onClose={handleCloseDetail}
+        />
+      )}
+    </div>
+  );
+}
+
+// Generation Detail Modal Component
+function GenerationDetailModal({
+  generation,
+  onClose,
+}: {
+  generation: CloudGeneration;
+  onClose: () => void;
+}) {
+  const handleDownload = async (url: string, index: number) => {
+    try {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = `generation-${generation.id}-variant-${index + 1}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
+    } catch (error) {
+      console.error("Failed to download image:", error);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2>Generation Details</h2>
+          <button onClick={onClose} className={styles.closeButton}>
+            ×
+          </button>
+        </div>
+
+        <div className={styles.modalContent}>
+          <div className={styles.detailRow}>
+            <strong>Created:</strong>
+            <span>
+              {new Date(generation.created_at).toLocaleString()}
+            </span>
+          </div>
+          <div className={styles.detailRow}>
+            <strong>Status:</strong>
+            <span style={{ 
+              color: generation.status === "complete" ? "#28a745" : 
+                     generation.status === "failed" ? "#dc3545" : "#6c757d" 
+            }}>
+              {generation.status}
+            </span>
+          </div>
+          {generation.error_message && (
+            <div className={styles.detailRow}>
+              <strong>Error:</strong>
+              <span style={{ color: "#dc3545" }}>{generation.error_message}</span>
+            </div>
+          )}
+          <div className={styles.detailRow}>
+            <strong>Prompt:</strong>
+            <p className={styles.fullPrompt}>{generation.prompt}</p>
+          </div>
+
+          {/* Outputs */}
+          {generation.outputs && generation.outputs.length > 0 && (
+            <div className={styles.outputsSection}>
+              <strong>Generated Images ({generation.outputs.length}):</strong>
+              <div className={styles.outputsGrid}>
+                {generation.outputs.map((output, index) => (
+                  <div key={output.id} className={styles.outputCard}>
+                    <img
+                      src={output.url}
+                      alt={`Variant ${index + 1}`}
+                      className={styles.outputImage}
+                    />
+                    <button
+                      onClick={() => handleDownload(output.url!, index)}
+                      className={styles.downloadButton}
+                    >
+                      Download
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/NavLinks.tsx
+++ b/components/NavLinks.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const NAV_LINKS = [
   { href: "/thumbnails", label: "Thumbnail Creator" },
   { href: "/video-seo", label: "Video SEO" },
+  { href: "/generations", label: "Generation History" },
 ];
 
 function isActivePath(pathname: string, href: string): boolean {


### PR DESCRIPTION
## Summary

This PR adds a dedicated view for users to browse and access their older past generations from previous sessions, addressing issue #19.

## Changes

- ✅ Created new `/generations` page to view all past thumbnail generations
- ✅ Added navigation link in main menu for easy access
- ✅ Implemented pagination with 'Load More' functionality using the existing API `before` parameter
- ✅ Added filtering by status (complete, failed, running, pending)
- ✅ Added search functionality to filter by prompt text
- ✅ Created modal view to show full generation details with all variants
- ✅ Added download functionality for individual generation outputs
- ✅ Responsive design with grid layout for generation cards
- ✅ Integrated with existing cloud storage and authentication system
- ✅ Protected with AuthGuard for authenticated users only

## Screenshots

The page features:
- Grid layout showing generation previews with thumbnails
- Status badges (complete, failed, running, pending) with color coding
- Timestamp and prompt preview for each generation
- Filter controls for status and search
- Load More button for pagination
- Modal detail view showing all variants with download buttons

## Testing

- ✅ Build passes successfully
- ✅ TypeScript compilation successful
- ✅ ESLint warnings only (no errors)
- ✅ Integrated with existing authentication flow
- ✅ Uses existing cloud storage API endpoints

## Related Issue

Closes #19

## Technical Notes

- Uses the existing `useHybridStorage` hook for data fetching
- Leverages the existing `refreshGenerations` method with pagination support
- Follows the same design patterns as `RefinementHistoryBrowser` component
- CSS module for scoped styling
- Responsive design with mobile support

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author