### PR TITLE
Resolve GitHub issue #29 in CreatorToolHub

### DIFF
--- a/app/api/generate-video-content/route.ts
+++ b/app/api/generate-video-content/route.ts
@@ -6,7 +6,7 @@ import { Autumn } from "autumn-js";
 
 const GEMINI_MODEL_ID = "gemini-2.5-pro";
 const RAPIDAPI_HOST = "io-youtube-transcriptor.p.rapidapi.com";
-const MAX_TRANSCRIPT_CHARACTERS = 8000;
+const MAX_TRANSCRIPT_CHARACTERS = 200000; // Increased to support 5+ hour videos (~4-5 hours of content)
 
 interface GenerateVideoContentRequest {
   youtubeUrl?: string;


### PR DESCRIPTION
Increased MAX_TRANSCRIPT_CHARACTERS from 8000 to 200000 to support 5+ hour videos. The previous limit of 8000 characters was causing transcripts to be cut off at approximately 14 minutes due to timestamp overhead.

Fixes #29