### PR TITLE
fix: progress bar exceeds thumbnail count with multiple providers

### DIFF
--- a/app/thumbnails/page.tsx
+++ b/app/thumbnails/page.tsx
@@ -908,8 +908,10 @@ export default function Home() {
 
 
         // Initialize overall progress across all selected templates
+        // Account for number of providers: each provider generates 'count' images per template
         const perTemplate = Math.max(1, count);
-        const overallTotal = perTemplate * ids.length;
+        const numProviders = selectedProviders.size;
+        const overallTotal = perTemplate * numProviders * ids.length;
         let overallDone = 0;
         setProgressTotal(overallTotal);
         setProgressDone(0);


### PR DESCRIPTION
## Summary

This PR fixes the progress bar exceeding the thumbnail count when using multiple AI providers.

## Problem

When users select multiple AI providers (e.g., Gemini and Fal-Flux), the progress bar total was only accounting for the number of thumbnails per template, not the total across all providers. For example:

- User requests 10 thumbnails
- Selects 2 providers
- UI shows "creating 10 thumbnails"
- Progress counter goes up to 12, 14, 20 (because each provider generates 10 images)

## Solution

Updated the progress total calculation to account for the number of selected providers:

```typescript
// Before (incorrect):
const overallTotal = perTemplate * ids.length;

// After (correct):
const numProviders = selectedProviders.size;
const overallTotal = perTemplate * numProviders * ids.length;
```

This matches the worker implementation which correctly calculates `totalExpectedImages = providersToUse.length * count`.

## Testing

- Build passes with no new type errors
- Progress bar should now correctly reflect the total number of thumbnails being generated across all selected providers

Fixes #57

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author