### PR TITLE
fix: Copy button in Refinement section now copies image instead of text

### DIFF
--- a/components/ThumbnailRefinement.tsx
+++ b/components/ThumbnailRefinement.tsx
@@ -383,8 +383,12 @@ export default function ThumbnailRefinement({
           const mimeMatch = /^data:([^;,]+)/.exec(src);
           const mimeType = mimeMatch ? mimeMatch[1] : YOUTUBE_THUMBNAIL.MIME_TYPE;
           dataUrl = `data:${mimeType};base64,${imageData}`;
+        } else if (src.startsWith('blob:')) {
+          // When src is a blob: URL, imageData is produced via canvas.toDataURL('image/png')
+          // in handleSelectThumbnailForRefinement, so the raw base64 is PNG bytes
+          dataUrl = `data:image/png;base64,${imageData}`;
         } else {
-          // Fallback to YOUTUBE_THUMBNAIL.MIME_TYPE for processed images (typically JPEG)
+          // Fallback to YOUTUBE_THUMBNAIL.MIME_TYPE for processed/refined images (JPEG)
           dataUrl = `data:${YOUTUBE_THUMBNAIL.MIME_TYPE};base64,${imageData}`;
         }
         blob = dataUrlToBlob(dataUrl);


### PR DESCRIPTION
## Summary

Fixes #42 - The Copy button in the Refinement section was copying text (the image URL) to the clipboard instead of the actual image.

## Problem

The Copy button in the thumbnail refinement area would copy the blob URL or data URL as text rather than the image itself. This happened because:
1. The error handling fell back to copying the URL as text when clipboard write failed
2. Blob URLs created in one context might not work reliably in another
3. Some browsers (especially Safari) have strict requirements about MIME types for clipboard writes

## Solution

1. **Prefer base64 data**: Modified `handleCopy` to use `imageData` (base64) when available, which is more reliable than blob URLs
2. **PNG conversion**: Added automatic PNG conversion for clipboard compatibility across browsers
3. **Better error handling**: Removed the text fallback (which was never useful for users) and replaced it with a user-friendly error message suggesting to download instead

## Changes

- Modified `handleCopy` function in `components/ThumbnailRefinement.tsx`
- Updated the Copy button click handler to pass `imageData` parameter

## Testing

- [x] TypeScript compilation passes
- [x] Next.js build passes (`npm run build`)

## Checklist

- [x] Code follows project conventions
- [x] Changes are focused and minimal
- [x] Commit message follows conventional commits format

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author